### PR TITLE
Fix Windows support for Rust 1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,17 @@
 name = "dylib"
 version = "0.0.2"
 dependencies = [
+ "errno 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "errno"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,32 @@
 name = "dylib"
 version = "0.0.2"
 dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ description = "Standalone version of former dylib module"
 
 [dependencies]
 libc = "*"
+winapi = "*"
+kernel32-sys = "*"
 
 [lib]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Standalone version of former dylib module"
 libc = "*"
 winapi = "*"
 kernel32-sys = "*"
+errno = "*"
 
 [lib]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 //! A simple wrapper over the platform's dynamic library facilities
 
 extern crate libc;
+extern crate winapi;
+extern crate kernel32;
+extern crate errno;
 
 use std::env;
 use std::ffi::{CString, OsString};
@@ -125,7 +128,7 @@ impl DynamicLibrary {
 mod test {
     use super::*;
     use std::mem;
-    use path::Path;
+    use winapi;
 
     #[test]
     #[cfg_attr(any(windows, target_os = "android"), ignore)] // FIXME #8818, #10379
@@ -137,7 +140,7 @@ mod test {
             Ok(libm) => libm
         };
 
-        let cosine: extern fn(libc::c_double) -> libc::c_double = unsafe {
+        let cosine: extern fn(winapi::c_double) -> winapi::c_double = unsafe {
             match libm.symbol("cos") {
                 Err(error) => panic!("Could not load function cos: {}", error),
                 Ok(cosine) => mem::transmute::<*mut u8, _>(cosine)
@@ -252,10 +255,6 @@ mod dl {
 }
 
 #[cfg(target_os = "windows")]
-extern crate winapi;
-extern crate kernel32;
-extern crate errno;
-
 mod dl {
     use std::ffi::OsStr;
     use std::iter::Iterator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ mod test {
     use super::*;
     use std::mem;
     use winapi;
+    use libc;
 
     #[test]
     #[cfg_attr(any(windows, target_os = "android"), ignore)] // FIXME #8818, #10379
@@ -200,7 +201,7 @@ mod dl {
         })
     }
 
-    const LAZY: winapi::c_int = 1;
+    const LAZY: libc::c_int = 1;
 
     unsafe fn open_external(filename: &OsStr) -> *mut u8 {
         let s = CString::new(filename.as_bytes()).unwrap(); //to_cstring().unwrap();
@@ -237,20 +238,20 @@ mod dl {
     }
 
     pub unsafe fn symbol(handle: *mut u8,
-                         symbol: *const winapi::c_char) -> *mut u8 {
-        dlsym(handle as *mut winapi::c_void, symbol) as *mut u8
+                         symbol: *const libc::c_char) -> *mut u8 {
+        dlsym(handle as *mut libc::c_void, symbol) as *mut u8
     }
     pub unsafe fn close(handle: *mut u8) {
-        dlclose(handle as *mut winapi::c_void); ()
+        dlclose(handle as *mut libc::c_void); ()
     }
 
     extern {
-        fn dlopen(filename: *const winapi::c_char,
-                  flag: winapi::c_int) -> *mut winapi::c_void;
-        fn dlerror() -> *mut winapi::c_char;
-        fn dlsym(handle: *mut winapi::c_void,
-                 symbol: *const winapi::c_char) -> *mut winapi::c_void;
-        fn dlclose(handle: *mut winapi::c_void) -> winapi::c_int;
+        fn dlopen(filename: *const libc::c_char,
+                  flag: libc::c_int) -> *mut libc::c_void;
+        fn dlerror() -> *mut libc::c_char;
+        fn dlsym(handle: *mut libc::c_void,
+                 symbol: *const libc::c_char) -> *mut libc::c_void;
+        fn dlclose(handle: *mut libc::c_void) -> libc::c_int;
     }
 }
 
@@ -272,6 +273,7 @@ mod dl {
     use std::vec::Vec;
     use kernel32::SetThreadErrorMode;
     use kernel32;
+    use libc;
 
     pub fn open(filename: Option<&OsStr>) -> Result<*mut u8, String> {
         // disable "dll load failed" error dialog.
@@ -306,7 +308,7 @@ mod dl {
                 let filename_str: Vec<_> =
                     filename.encode_wide().chain(Some(0).into_iter()).collect();
                 let result = unsafe {
-                    LoadLibraryW(filename_str.as_ptr() as *const winapi::c_void)
+                    LoadLibraryW(filename_str.as_ptr() as *const libc::c_void)
                 };
                 // beware: Vec/String may change errno during drop!
                 // so we get error here.
@@ -359,22 +361,22 @@ mod dl {
         }
     }
 
-    pub unsafe fn symbol(handle: *mut u8, symbol: *const winapi::c_char) -> *mut u8 {
-        GetProcAddress(handle as *mut winapi::c_void, symbol) as *mut u8
+    pub unsafe fn symbol(handle: *mut u8, symbol: *const libc::c_char) -> *mut u8 {
+        GetProcAddress(handle as *mut libc::c_void, symbol) as *mut u8
     }
     pub unsafe fn close(handle: *mut u8) {
-        FreeLibrary(handle as *mut winapi::c_void); ()
+        FreeLibrary(handle as *mut libc::c_void); ()
     }
 
     #[allow(non_snake_case)]
     extern "system" {
-        fn SetLastError(error: winapi::size_t);
-        fn LoadLibraryW(name: *const winapi::c_void) -> *mut winapi::c_void;
+        fn SetLastError(error: libc::size_t);
+        fn LoadLibraryW(name: *const libc::c_void) -> *mut libc::c_void;
         fn GetModuleHandleExW(dwFlags: minwindef::DWORD, name: *const u16,
-                              handle: *mut *mut winapi::c_void) -> minwindef::BOOL;
-        fn GetProcAddress(handle: *mut winapi::c_void,
-                          name: *const winapi::c_char) -> *mut winapi::c_void;
-        fn FreeLibrary(handle: *mut winapi::c_void);
-        fn SetErrorMode(uMode: winapi::c_uint) -> winapi::c_uint;
+                              handle: *mut *mut libc::c_void) -> minwindef::BOOL;
+        fn GetProcAddress(handle: *mut libc::c_void,
+                          name: *const libc::c_char) -> *mut libc::c_void;
+        fn FreeLibrary(handle: *mut libc::c_void);
+        fn SetErrorMode(uMode: libc::c_uint) -> libc::c_uint;
     }
 }


### PR DESCRIPTION
Apparently before 1.5 this only worked by coincidence as a bug in rust (extern crate libc being in std). This fixes it by using winapi, kernel32, and errno crates. This should actually be broken on *nix as well since os::errno is no longer a public API in 1.5. I haven't tested that this works on any other platform, only Windows 64bit MSVC ABI.. but it looks like it should work
